### PR TITLE
extract constants to const file, separate logs.confirm_text function,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ Or via environment variables:
 * `THEFUCK_RULES` &ndash; list of enabled rules, like `DEFAULT_RULES:rm_root` or `sudo:no_command`;
 * `THEFUCK_EXCLUDE_RULES` &ndash; list of disabled rules, like `git_pull:git_push`;
 * `THEFUCK_REQUIRE_CONFIRMATION` &ndash; require confirmation before running new command, `true/false`;
+* `THEFUCK_REQUIRE_DOUBLE_CONFIRMATION` &ndash; require double confirmation before running potentially volitile commands (eg. `reboot`), value of `true/false`;
 * `THEFUCK_WAIT_COMMAND` &ndash; max amount of time in seconds for getting previous command output;
 * `THEFUCK_NO_COLORS` &ndash; disable colored output, `true/false`;
 * `THEFUCK_PRIORITY` &ndash; priority of the rules, like `no_command=9999:apt_get=100`,

--- a/thefuck/const.py
+++ b/thefuck/const.py
@@ -28,10 +28,13 @@ ALL_ENABLED = _GenConst('All rules enabled')
 DEFAULT_RULES = [ALL_ENABLED]
 DEFAULT_PRIORITY = 1000
 
+DOUBLE_CONFIRMATION_SCRIPTS = {"reboot": "Are you sure you would like to reboot the system?"}
+
 DEFAULT_SETTINGS = {'rules': DEFAULT_RULES,
                     'exclude_rules': [],
                     'wait_command': 3,
                     'require_confirmation': True,
+                    'require_double_confirmation': False,
                     'no_colors': False,
                     'debug': False,
                     'priority': {},
@@ -49,6 +52,7 @@ ENV_TO_ATTR = {'THEFUCK_RULES': 'rules',
                'THEFUCK_EXCLUDE_RULES': 'exclude_rules',
                'THEFUCK_WAIT_COMMAND': 'wait_command',
                'THEFUCK_REQUIRE_CONFIRMATION': 'require_confirmation',
+               'THEFUCK_REQUIRE_DOUBLE_CONFIRMATION': 'require_double_confirmation',
                'THEFUCK_NO_COLORS': 'no_colors',
                'THEFUCK_DEBUG': 'debug',
                'THEFUCK_PRIORITY': 'priority',

--- a/thefuck/entrypoints/fix_command.py
+++ b/thefuck/entrypoints/fix_command.py
@@ -6,7 +6,7 @@ from .. import logs, types, const
 from ..conf import settings
 from ..corrector import get_corrected_commands
 from ..exceptions import EmptyCommand
-from ..ui import select_command, confirm_command
+from ..ui import select_command
 from ..utils import get_alias, get_all_executables
 
 
@@ -41,7 +41,7 @@ def fix_command(known_args):
 
         corrected_commands = get_corrected_commands(command)
         selected_command = select_command(corrected_commands)
-        
+
         if selected_command:
             selected_command.run(command)
         else:

--- a/thefuck/entrypoints/fix_command.py
+++ b/thefuck/entrypoints/fix_command.py
@@ -29,7 +29,6 @@ def _get_raw_command(known_args):
 def fix_command(known_args):
     """Fixes previous command. Used when `thefuck` called without arguments."""
     settings.init(known_args)
-    double_check_commands = {"reboot": "reboot system?"}
     with logs.debug_time('Total'):
         logs.debug(u'Run with settings: {}'.format(pformat(settings)))
         raw_command = _get_raw_command(known_args)
@@ -42,12 +41,8 @@ def fix_command(known_args):
 
         corrected_commands = get_corrected_commands(command)
         selected_command = select_command(corrected_commands)
-
-        confirmation = True
-        if selected_command.script in double_check_commands:
-            confirmation = confirm_command(double_check_commands[selected_command.script])
-
-        if selected_command and confirmation:
+        
+        if selected_command:
             selected_command.run(command)
         else:
             sys.exit(1)

--- a/thefuck/logs.py
+++ b/thefuck/logs.py
@@ -71,6 +71,7 @@ def confirm_text(corrected_command):
             reset=color(colorama.Style.RESET_ALL),
             blue=color(colorama.Fore.BLUE)))
 
+
 def double_confirm_text(confirmation_text):
     sys.stderr.write(
         (u'{prefix}{clear}{bold}{text}{reset} '
@@ -83,7 +84,7 @@ def double_confirm_text(confirmation_text):
             green=color(colorama.Fore.GREEN),
             red=color(colorama.Fore.RED),
             reset=color(colorama.Style.RESET_ALL),
-            ))
+        ))
 
 
 def debug(msg):

--- a/thefuck/logs.py
+++ b/thefuck/logs.py
@@ -57,33 +57,34 @@ def show_corrected_command(corrected_command):
 
 
 def confirm_text(corrected_command):
-    if corrected_command.script != 'reboot system?':
-        sys.stderr.write(
-            (u'{prefix}{clear}{bold}{script}{reset}{side_effect} '
-            u'[{green}enter{reset}/{blue}↑{reset}/{blue}↓{reset}'
-            u'/{red}ctrl+c{reset}]').format(
-                prefix=const.USER_COMMAND_MARK,
-                script=corrected_command.script,
-                side_effect=' (+side effect)' if corrected_command.side_effect else '',
-                clear='\033[1K\r',
-                bold=color(colorama.Style.BRIGHT),
-                green=color(colorama.Fore.GREEN),
-                red=color(colorama.Fore.RED),
-                reset=color(colorama.Style.RESET_ALL),
-                blue=color(colorama.Fore.BLUE)))
-    else:
-        sys.stderr.write(
-            (u'{prefix}{clear}{bold}{script}{reset}{side_effect} '
-             u'[{green}enter{reset}'
-             u'/{red}ctrl+c{reset}]').format(
-                prefix=const.USER_COMMAND_MARK,
-                script=corrected_command.script,
-                side_effect=' (+side effect)' if corrected_command.side_effect else '',
-                clear='\033[1K\r',
-                bold=color(colorama.Style.BRIGHT),
-                green=color(colorama.Fore.GREEN),
-                red=color(colorama.Fore.RED),
-                reset=color(colorama.Style.RESET_ALL)))
+    sys.stderr.write(
+        (u'{prefix}{clear}{bold}{script}{reset}{side_effect} '
+         u'[{green}enter{reset}/{blue}↑{reset}/{blue}↓{reset}'
+         u'/{red}ctrl+c{reset}]').format(
+            prefix=const.USER_COMMAND_MARK,
+            script=corrected_command.script,
+            side_effect=' (+side effect)' if corrected_command.side_effect else '',
+            clear='\033[1K\r',
+            bold=color(colorama.Style.BRIGHT),
+            green=color(colorama.Fore.GREEN),
+            red=color(colorama.Fore.RED),
+            reset=color(colorama.Style.RESET_ALL),
+            blue=color(colorama.Fore.BLUE)))
+
+def double_confirm_text(confirmation_text):
+    sys.stderr.write(
+        (u'{prefix}{clear}{bold}{text}{reset} '
+         u'[{green}enter{reset}'
+         u'/{red}ctrl+c{reset}]').format(
+            prefix=const.USER_COMMAND_MARK,
+            text=confirmation_text,
+            clear='\033[1K\r',
+            bold=color(colorama.Style.BRIGHT),
+            green=color(colorama.Fore.GREEN),
+            red=color(colorama.Fore.RED),
+            reset=color(colorama.Style.RESET_ALL),
+            ))
+
 
 def debug(msg):
     if settings.debug:
@@ -152,16 +153,3 @@ def version(thefuck_version, python_version, shell_info):
         u'The Fuck {} using Python {} and {}\n'.format(thefuck_version,
                                                        python_version,
                                                        shell_info))
-
-
-def confirmation(confirm, msg):
-    if confirm is True:
-        sys.stderr.write(u"\n{bold}System will now {message}\n{reset}".format(
-            bold=color(colorama.Style.BRIGHT),
-            message=msg[:-1],
-            reset=color(colorama.Style.RESET_ALL)))
-    else:
-        sys.stderr.write(u"\n{bold}{message} cancelled{reset}\n".format(
-            bold=color(colorama.Style.BRIGHT),
-            message=msg[:-1],
-            reset=color(colorama.Style.RESET_ALL)))

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -100,6 +100,8 @@ def select_command(corrected_commands):
     if settings.require_double_confirmation and selector.value.script in const.DOUBLE_CONFIRMATION_SCRIPTS:
         selector.value = double_confirm(selector)
 
+    return selector.value
+
 
 def double_confirm(selector):
     confirmation_text = const.DOUBLE_CONFIRMATION_SCRIPTS[selector.value.script]

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -81,10 +81,13 @@ def select_command(corrected_commands):
 
     logs.confirm_text(selector.value)
 
-    for action in read_actions():
+    selected = False
+    while not selected:
+        action = next(read_actions())
+
         if action == const.ACTION_SELECT:
             sys.stderr.write('\n')
-            return selector.value
+            selected = True
         elif action == const.ACTION_ABORT:
             logs.failed('\nAborted')
             return
@@ -95,26 +98,17 @@ def select_command(corrected_commands):
             selector.next()
             logs.confirm_text(selector.value)
 
+    
+    if not (settings.require_double_confirmation and selector.value.script in const.DOUBLE_CONFIRMATION_SCRIPTS):
+        return selector.value
+        
+    confirmation_text = const.DOUBLE_CONFIRMATION_SCRIPTS[selector.value.script]
+    logs.double_confirm_text(confirmation_text)
 
-def confirm_command(confirmation_text):
-    """Returns:
-
-     - the first command when confirmation disabled;
-     - None when ctrl+c pressed;
-     - selected command.
-
-    :type corrected_commands: Iterable[thefuck.types.CorrectedCommand]
-    :rtype: thefuck.types.CorrectedCommand | None
-
-    """
-
-    logs.confirm_text(CorrectedCommand(confirmation_text, None, 0))
-
-    action = read_actions()
     for action in read_actions():
         if action == const.ACTION_SELECT:
-            logs.confirmation(True, confirmation_text)
-            return True
+            sys.stderr.write('\n')
+            return selector.value
         elif action == const.ACTION_ABORT:
-            logs.confirmation(False, confirmation_text)
-            return False
+            logs.failed('\nAborted')
+            return

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -6,7 +6,6 @@ from .exceptions import NoRuleMatched
 from .system import get_key
 from .utils import get_alias
 from . import logs, const
-from .types import CorrectedCommand
 
 
 def read_actions():
@@ -98,11 +97,11 @@ def select_command(corrected_commands):
             selector.next()
             logs.confirm_text(selector.value)
 
-    
-    if not (settings.require_double_confirmation and selector.value.script in const.DOUBLE_CONFIRMATION_SCRIPTS):
-        return selector.value
-        
-    confirmation_text = const.DOUBLE_CONFIRMATION_SCRIPTS[selector.value.script]
+    if settings.require_double_confirmation and selector.value.script in const.DOUBLE_CONFIRMATION_SCRIPTS:
+        selector.value = double_confirm(const.DOUBLE_CONFIRMATION_SCRIPTS[selector.value.script])
+
+
+def double_confirm(confirmation_text):
     logs.double_confirm_text(confirmation_text)
 
     for action in read_actions():

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -98,7 +98,7 @@ def select_command(corrected_commands):
             logs.confirm_text(selector.value)
 
     if settings.require_double_confirmation and selector.value.script in const.DOUBLE_CONFIRMATION_SCRIPTS:
-        selector.value = double_confirm(selector)
+        return double_confirm(selector)
 
     return selector.value
 

--- a/thefuck/ui.py
+++ b/thefuck/ui.py
@@ -98,10 +98,11 @@ def select_command(corrected_commands):
             logs.confirm_text(selector.value)
 
     if settings.require_double_confirmation and selector.value.script in const.DOUBLE_CONFIRMATION_SCRIPTS:
-        selector.value = double_confirm(const.DOUBLE_CONFIRMATION_SCRIPTS[selector.value.script])
+        selector.value = double_confirm(selector)
 
 
-def double_confirm(confirmation_text):
+def double_confirm(selector):
+    confirmation_text = const.DOUBLE_CONFIRMATION_SCRIPTS[selector.value.script]
     logs.double_confirm_text(confirmation_text)
 
     for action in read_actions():


### PR DESCRIPTION
… remove confirmation log function, add env variable for double confirms

Moved the constants declared in the fix_command file to the dedicated constants file.

seperated the command_text file into two different functions so that there isn't another check for if its in the double confirm dict

moved double confirm logic from fix_command into select_command in the ui. I think this would make more sense because the underlying program shouldn't really care about confirmations.

making double confirm off by default with a environment variable required to turn it on. This might be helpful if we try to make a pr for this in the main repo.

update readme to reflect this